### PR TITLE
Fix auth issue in get_instance_host

### DIFF
--- a/quantum/plugins/cisco/models/virt_phy_sw_v2.py
+++ b/quantum/plugins/cisco/models/virt_phy_sw_v2.py
@@ -203,16 +203,10 @@ class VirtualPhysicalSwitchModelV2(quantum_plugin_base_v2.QuantumPluginBaseV2):
 
     def _get_instance_host(self, tenant_id, instance_id):
         keystone = cred._creds_dictionary['keystone']
-        kc = keystone_client.Client(username=keystone['username'],
-                                    password=keystone['password'],
-                                    tenant_id=tenant_id,
-                                    auth_url=keystone['auth_url'])
-        tenant = kc.tenants.get(tenant_id)
-        tenant_name = tenant.name
 
         nc = nova_client.Client(keystone['username'],
                                 keystone['password'],
-                                tenant_name,
+                                keystone['tenant'],
                                 keystone['auth_url'],
                                 no_cache=True)
         serv = nc.servers.get(instance_id)


### PR DESCRIPTION
_get_instance_host was attempting to use the
admin username and password with the user's
tenant, which leads to 401 auth errors from
Keystone when attempting to determine the
instance host from nova.

This patch reads the admin tenant from the same
place as the username and password and uses that
instead. It also removes the keystone call that
was used to determine the tenant_id from the name,
since that is no longer needed.
