### PR TITLE
Fix missing reference service_provider for VPNaaS

### DIFF
--- a/etc/neutron.conf
+++ b/etc/neutron.conf
@@ -369,3 +369,4 @@ signing_dir = $state_path/keystone-signing
 # service_provider=FIREWALL:name2:firewall_driver_path
 # --- Reference implementations ---
 service_provider=LOADBALANCER:Haproxy:neutron.services.loadbalancer.drivers.haproxy.plugin_driver.HaproxyOnHostPluginDriver:default
+service_provider=VPN:openswan:neutron.services.vpn.service_drivers.ipsec.IPsecVPNDriver:default


### PR DESCRIPTION
In Neutron's stable/havana branch, the sample neutron.conf file
is missing a service_providers line for the reference
open source backend for VPNaaS (OpenSwan).  Since packaging relies
on this to provide a default value, VPNaaS doesn't work out of the
box in Havana.  This has been corrected upstream in Icehouse, but
the fix looks unlikely to be backported to stable/havana at this
point so we'll carry it locally.

Partial-Bug: #1301418
