### PR TITLE
Support for disabling anti spoofing

### DIFF
--- a/neutron/agent/linux/iptables_firewall.py
+++ b/neutron/agent/linux/iptables_firewall.py
@@ -281,7 +281,8 @@ class IptablesFirewallDriver(firewall.FirewallDriver):
                 else:
                     break   # Leave loop if False
             if('security_group_name' in line):
-                secGroupServiceVM = line.rsplit(' ')[2].rstrip()
+                secGroupServiceVMString = line.rsplit(' ')[2].rstrip()
+                secGroupServiceVM = secGroupServiceVMString[1:-1].split(',')
                 if(antiSpoofingDisabled):
                     break   # Both parameters found
             line = f.readline()
@@ -304,13 +305,13 @@ class IptablesFirewallDriver(firewall.FirewallDriver):
                 try:
                     for secgrid in port['security_groups']:
                         secgrp = neutronClient.show_security_group(secgrid)
-                        if secgrp['security_group']['name']==secGroupServiceVM:
+                        if secgrp['security_group']['name'] in secGroupServiceVM:
                             break
                 except exceptions.NeutronException as e:
                     LOG.error(_('Neutron Client show_security_group call error: %s for sec group id %s'), str(e), str(secgrid))
                                 
                 # If this is the security group name specified, don't apply spoofing rule.
-                if(secgrp['security_group']['name']!=secGroupServiceVM):
+                if(secgrp['security_group']['name'] not in secGroupServiceVM):
                     self._spoofing_rule(port,
                                         ipv4_iptables_rule,
                                         ipv6_iptables_rule)


### PR DESCRIPTION
Modified the iptables_firewall file to add support for disabling anti spoofing in /etc/neutron/neutron.conf. The parameters read in the latter are "disable_anti_spoofing = True" (or False) and "security_group_name = nameDefinedByUser". Those 2 parameters are optional for this to work (if they don't exist, default behavior will take place).
At this point, the user can create a security group with the name defined in neutron.conf, and after creating a port that uses this security group, any instances spun up and associated with that port will have anti spoofing disabled.

Nabil M.
nmaadara@cisco.com
