### PR TITLE
Prevent allowed-address-pair port-update commands

### DIFF
--- a/neutron/plugins/openvswitch/ovs_neutron_plugin.py
+++ b/neutron/plugins/openvswitch/ovs_neutron_plugin.py
@@ -589,6 +589,13 @@ class OVSNeutronPluginV2(db_base_plugin_v2.NeutronDbPluginV2,
             updated_port = super(OVSNeutronPluginV2, self).update_port(
                 context, id, port)
             if addr_pair.ADDRESS_PAIRS in port['port']:
+                my_network_id = original_port['network_id']
+                my_device_owner = updated_port['device_owner']
+                my_network = super(OVSNeutronPluginV2, self).get_network(
+                    context,my_network_id, None)
+                if my_network.get('shared') and my_device_owner != "network:dhcp":
+                    msg = _("allowed-address-pairs is not supported on a shared network")
+                    raise q_exc.InvalidInput(error_message=msg)
                 self._delete_allowed_address_pairs(context, id)
                 self._process_create_allowed_address_pairs(
                     context, updated_port,


### PR DESCRIPTION
This patch is a forward-port of a patch from puppet-coe-service-patch
which had the following commit message:

---

commit 98f45411c5305c297881d6477e5b4b6ac121d19d
Author: Kevin Bringard kevinbri@cisco.com
Date:   Thu Jun 19 11:37:17 2014 -0600

```
Prevent allowed-address-pair port-update commands on shared networks

We have to check for dhcp agents as they need to update the allowed
address pairs, and functionality will break if we don't allow for it.

This code is currently running in SVL2 and is being tested by SDU

Change-Id: Id4f9ee93b9e5efd147f176b7aa76f4e4206c48e
```

---

Implements: rally-user-story US4145
Implements: rally-task TA3473
Not-in-upstream: true
