### PR TITLE
Verify subnet configuration has valid CIDR & GW

### DIFF
--- a/neutron/agent/dhcp_agent.py
+++ b/neutron/agent/dhcp_agent.py
@@ -31,6 +31,7 @@ from neutron.common import exceptions
 from neutron.common import legacy
 from neutron.common import topics
 from neutron.common import utils
+from neutron.common import exceptions as q_exc
 from neutron import context
 from neutron import manager
 from neutron.openstack.common import importutils
@@ -284,6 +285,17 @@ class DhcpAgent(manager.Manager):
     @utils.synchronized('dhcp-agent')
     def subnet_update_end(self, context, payload):
         """Handle the subnet.update.end notification event."""
+        try:
+            ip = netaddr.IPNetwork(payload['subnet']['cidr'])
+            if ip.size < 8:
+                msg = _("%s has size %d") % (payload['subnet']['cidr'], ip.size)
+                raise q_exc.BadRequest(resource='subnet', msg=msg)
+            gw = netaddr.IPAddress(payload['subnet']['gateway_ip'])            
+            if gw not in ip:
+                msg = _("%s is not in network %s") % (payload['subnet']['gateway_ip'], payload['subnet']['cidr'])
+                raise q_exc.BadRequest(resource='subnet', msg=msg)
+        except:
+            raise
         network_id = payload['subnet']['network_id']
         self.refresh_dhcp_helper(network_id)
 

--- a/neutron/tests/unit/test_dhcp_agent.py
+++ b/neutron/tests/unit/test_dhcp_agent.py
@@ -700,7 +700,9 @@ class TestDhcpAgentEventHandler(base.BaseTestCase):
             self.assertTrue(self.dhcp.needs_resync)
 
     def test_subnet_update_end(self):
-        payload = dict(subnet=dict(network_id=fake_network.id))
+        payload = dict(subnet=dict(network_id=fake_network.id,
+                                   cidr=fake_subnet1.cidr,
+                                   gateway_ip=fake_subnet1.gateway_ip))
         self.cache.get_network_by_id.return_value = fake_network
         self.plugin.get_network_info.return_value = fake_network
 
@@ -717,7 +719,9 @@ class TestDhcpAgentEventHandler(base.BaseTestCase):
                                   subnets=[fake_subnet1, fake_subnet3],
                                   ports=[fake_port1]))
 
-        payload = dict(subnet=dict(network_id=fake_network.id))
+        payload = dict(subnet=dict(network_id=fake_network.id,
+                                   cidr=fake_subnet1.cidr,
+                                   gateway_ip=fake_subnet1.gateway_ip))
         self.cache.get_network_by_id.return_value = fake_network
         self.plugin.get_network_info.return_value = new_state
 
@@ -734,7 +738,9 @@ class TestDhcpAgentEventHandler(base.BaseTestCase):
                                    subnets=[fake_subnet1, fake_subnet3],
                                    ports=[fake_port1]))
 
-        payload = dict(subnet_id=fake_subnet1.id)
+        payload = dict(subnet_id=fake_subnet1.id,
+                       cidr=fake_subnet1.cidr,
+                       gateway_ip=fake_subnet1.gateway_ip)
         self.cache.get_network_by_subnet_id.return_value = prev_state
         self.cache.get_network_by_id.return_value = prev_state
         self.plugin.get_network_info.return_value = fake_network


### PR DESCRIPTION
This patch is a forward porting of three closely related patches
from the puppet-coe-service-patch module that are intended
to block creation of /30, /31, and /32 subnets.  The commit log
messages from the original patches are below.  These are partly
related to upstream bug #1341040 for which the community has
adopted a different and less strict approach.  We have opted
for a stricter approach, so we'll need to carry this patch for now.

---

commit 8dabd46a2f9827e9b10dfe3461a986392ad7d82f
Author: Pauline Yeung yeungp@cisco.com
Date:   Thu Jul 24 15:45:07 2014 -0700

```
DE631 block /30 in neutron server, in addition to blocking in
CLI and dhcp an addition to blocking in CLI and dhcp agent.

Change-Id: If405e49b8faa4c6a584441ee93dab211a8f521e6
```

---

---

commit dff604420c48dfe47467cdd1b48687443fb7b32a
Author: Pauline Yeung yeungp@cisco.com
Date:   Wed Jul 23 17:49:45 2014 -0700

```
DE631 do not allow /30, as creating the first VM may require network
with at least 5 IP addresses.

Change-Id: I1bb48a512adeb509073b8b1c61520db8ea555768
```

---

---

```
commit 3a3d4e95720846a2ed3439c46bf33407da08a2d2
Author: Pauline Yeung <yeungp@cisco.com>
Date:   Thu Jul 17 17:16:20 2014 -0700

    DE494 add CIDR and gateway IP to payload, data which always exists
    in a subnload, data which always exists in a subnet.

    Change-Id: I30121506fb918f6e5932e627d07067d289194a9d
```

---

Partial-bug: #1341040
Partial-rally-bug: rally-bug DE631
Partial-rally-bug: rally-bug DE494
Implements: rally-user-story US4145
Implements: rally-task TA3473
Not-in-upstream: true
