### PR TITLE
Change metadata-agent to spawn multiple workers

### DIFF
--- a/etc/metadata_agent.ini
+++ b/etc/metadata_agent.ini
@@ -26,3 +26,9 @@ admin_password = %SERVICE_PASSWORD%
 
 # Location of Metadata Proxy UNIX domain socket
 # metadata_proxy_socket = $state_path/metadata_proxy
+
+# Number of separate worker processes for metadata server
+# metadata_workers = 0
+
+# Number of backlog requests to configure the metadata server socket with
+# metadata_backlog = 128


### PR DESCRIPTION
There is currently only one metadata-agent per network node,
which could be handling connections from hundreds or thousands
of metadata-namespace-proxy processes.

This change addes a new "metadata_workers = XX" to the ini file
to support creating more workers to help improve performance.

Partial-bug: #1274536
Implements: rally-user-story US4047
Implements: rally-task TA3195
Upstream-Review: https://review.openstack.org/#/c/70204/
Not-in-upstream: false
