### PR TITLE
Block /30, /31, /32 on neutron server

### DIFF
--- a/neutron/db/db_base_plugin_v2.py
+++ b/neutron/db/db_base_plugin_v2.py
@@ -752,6 +752,11 @@ class NeutronDbPluginV2(neutron_plugin_base_v2.NeutronPluginBaseV2,
                            'subnet_id': subnet.id,
                            'cidr': subnet.cidr})
                 raise q_exc.InvalidInput(error_message=err_msg)
+        new_ip = netaddr.IPNetwork(new_subnet_cidr)
+        if new_ip.size < 8:
+            err_msg = (_("%s has size %d") % (new_subnet_cidr, new_ip.size))
+            LOG.error(err_msg)
+            raise q_exc.InvalidInput(error_message=err_msg)
 
     def _validate_allocation_pools(self, ip_pools, subnet_cidr):
         """Validate IP allocation pools.


### PR DESCRIPTION
This patch is a forward-port of a change to puppet-coe-service-patch
that deals with assuring that very small subnet masks aren't used
on networks created by neutron.  The patch is partly related to
upstream bug #1341040 for which the community has
adopted a different and less strict approach. We have opted
for a stricter approach, so we'll need to carry this patch for now.
The original commit message follows:
## 

commit 8dabd46a2f9827e9b10dfe3461a986392ad7d82f
Author: Pauline Yeung yeungp@cisco.com
Date:   Thu Jul 24 15:45:07 2014 -0700

```
DE631 block /30 in neutron server, in addition to blocking in CLI and
dhcp an addition to blocking in CLI and dhcp agent.

Change-Id: If405e49b8faa4c6a584441ee93dab211a8f521e6
```
## 

Partial-bug: #1341040
Partial-rally-bug: rally-bug DE631
Partial-rally-bug: rally-bug DE494
Implements: rally-user-story US4145
Implements: rally-task TA3473
Not-in-upstream: true
