### PR TITLE
Change metadata-agent to have a configurable backlog

### DIFF
--- a/neutron/agent/metadata/agent.py
+++ b/neutron/agent/metadata/agent.py
@@ -201,7 +201,7 @@ class UnixDomainWSGIServer(wsgi.Server):
         self._server = None
         super(UnixDomainWSGIServer, self).__init__(name)
 
-    def start(self, application, file_socket, workers, backlog=128):
+    def start(self, application, file_socket, workers, backlog):
         self._socket = eventlet.listen(file_socket,
                                        family=socket.AF_UNIX,
                                        backlog=backlog)


### PR DESCRIPTION
The metadata agent currently runs with a default socket backlog
of 128.  This isn't enough on a busy network node, even when
spawning multiple worker processes.

This change addes a new "metadata_backlog = XX" to the ini file
to support a configurable value to help improve performance.

Change-Id: Ibea398f3b65a56deb1418f39810d87d8360ea9f3
Closes-bug: #1274536
(cherry picked from commit acc21edca49b866e2c2d6e208aaa573d2f95fd88)

Implements: rally-user-story US4049
