### PR TITLE
Update cisco_plugins.ini

### DIFF
--- a/etc/neutron/plugins/cisco/cisco_plugins.ini
+++ b/etc/neutron/plugins/cisco/cisco_plugins.ini
@@ -154,3 +154,10 @@
 # Default value: False, indicating no full sync will be performed.
 #
 # enable_sync_on_start = False
+
+
+# (BoolOpt) Specify whether plugin should attempt to synchronize with the VSM
+# when there is a connection failure to the VSM.
+# Default value: False, indicating no full sync will be performed.
+#
+# enable_sync_on_error = False


### PR DESCRIPTION
Addin a new variable 'enable_sync_on_error' to help the VSM and the OpenStack remain in sync.
