### PR TITLE
Backport of https://review.openstack.org/#/c/108272/3 from Juno tip.

### DIFF
--- a/neutron/agent/linux/dhcp.py
+++ b/neutron/agent/linux/dhcp.py
@@ -319,7 +319,7 @@ class Dnsmasq(DhcpLocalProcess):
             '--dhcp-hostsfile=%s' % self._output_hosts_file(),
             '--addn-hosts=%s' % self._output_addn_hosts_file(),
             '--dhcp-optsfile=%s' % self._output_opts_file(),
-            '--leasefile-ro',
+            '--dhcp-leasefile=%s' % self.get_conf_file_name('lease'),
         ]
 
         possible_leases = 0

--- a/neutron/tests/unit/test_linux_dhcp.py
+++ b/neutron/tests/unit/test_linux_dhcp.py
@@ -649,7 +649,7 @@ class TestDnsmasq(TestBase):
             '--dhcp-hostsfile=/dhcp/%s/host' % network.id,
             '--addn-hosts=/dhcp/%s/addn_hosts' % network.id,
             '--dhcp-optsfile=/dhcp/%s/opts' % network.id,
-            '--leasefile-ro']
+            '--dhcp-leasefile=/dhcp/%s/lease' % network.id]
 
         expected.extend(
             '--dhcp-range=set:tag%d,%s,static,86400s' %


### PR DESCRIPTION
It has yet to be fully accepted, but I don't forsee any major code changes
and this should address our issue with the dhcpnak replies after a restart.

Partial-rally-bug: DE494
