### PR TITLE
Update the allowed-address-pairs denial patch for shared-nets

### DIFF
--- a/neutron/plugins/openvswitch/ovs_neutron_plugin.py
+++ b/neutron/plugins/openvswitch/ovs_neutron_plugin.py
@@ -593,7 +593,8 @@ class OVSNeutronPluginV2(db_base_plugin_v2.NeutronDbPluginV2,
                 my_device_owner = updated_port['device_owner']
                 my_network = super(OVSNeutronPluginV2, self).get_network(
                     context,my_network_id, None)
-                if my_network.get('shared') and my_device_owner != "network:dhcp":
+                if my_network.get('shared') and (my_device_owner != "network:dhcp"
+                    and my_device_owner != "neutron:LOADBALANCER"):
                     msg = _("allowed-address-pairs is not supported on a shared network")
                     raise q_exc.InvalidInput(error_message=msg)
                 self._delete_allowed_address_pairs(context, id)


### PR DESCRIPTION
This update will allow the allowed-address-pairs denial patch for the
shared nets to properly allow loadbalancers to update the allowed-address-pairs
on shared-nets (and most specifically the public direct net).

It was added to the puppet-coe-service-patch repo, but it seems it didn't
get entirely frontported. This should finish it off.

Closes-rally-bug: DE646
