### PR TITLE
Don't raise MySQL 2013 'Lost connection' errors

### DIFF
--- a/neutron/openstack/common/db/sqlalchemy/session.py
+++ b/neutron/openstack/common/db/sqlalchemy/session.py
@@ -613,7 +613,7 @@ def _is_db_connection_error(args):
     """Return True if error in connecting to db."""
     # NOTE(adam_g): This is currently MySQL specific and needs to be extended
     #               to support Postgres and others.
-    conn_err_codes = ('2002', '2003', '2006')
+    conn_err_codes = ('2002', '2003', '2006', '2013')
     for err_code in conn_err_codes:
         if args.find(err_code) != -1:
             return True


### PR DESCRIPTION
Closes-bug: #1276510

Although this code error is part of the `ping_listener` tests, it was
missing from the list of known - and ignored - connection errors.

The code error 2013 refers to a connection lost during a query, see:
https://dev.mysql.com/doc/refman/5.0/en/error-messages-client.html#error_cr_server_lost

Without this error code, the session won't try to reconnect to mysql,
which makes `max_retries` useless.

Change-Id: I57ac5a28f618b748f2c5a7657cc003bb8f2c0146

Not-in-upstream: true
Partial-rally-bug: DE770
Upstream-review: https://review.openstack.org/#/c/73793/
