### PR TITLE
DE734: Instance not getting DHCP due to missing of vlan tag on openvswitch port

### DIFF
--- a/neutron/agent/linux/ovs_lib.py
+++ b/neutron/agent/linux/ovs_lib.py
@@ -308,6 +308,37 @@ class OVSBridge(BaseOVS):
     def get_port_stats(self, port_name):
         return self.db_get_map("Interface", port_name, "statistics")
 
+    def get_port_tag_dict(self):
+        """
+        Get a dict of port names and associated vlan tags.
+
+        e.g. the returned dict is of the following form::
+
+            {u'int-br-eth2': [],
+             u'patch-tun': [],
+             u'qr-76d9e6b6-21': 1,
+             u'tapce5318ff-78': 1,
+             u'tape1400310-e6': 1}
+
+        The TAG ID is only available in the "Port" table and is not available
+        in the "Interface" table queried by the get_vif_port_set() method.
+
+        """
+        port_names = self.get_port_name_list()
+        args = ['--format=json', '--', '--columns=name,tag', 'list', 'Port']
+        result = self.run_vsctl(args)
+        port_tag_dict = {}
+        if not result:
+            return port_tag_dict
+        for name, tag in jsonutils.loads(result)['data']:
+            if name not in port_names:
+                continue
+            # 'tag' can be [u'set', []] or an integer
+            if isinstance(tag, list):
+                tag = tag[1]
+            port_tag_dict[name] = tag
+        return port_tag_dict
+
     def get_xapi_iface_id(self, xs_vif_uuid):
         args = ["xe", "vif-param-get", "param-name=other-config",
                 "param-key=nicira-iface-id", "uuid=%s" % xs_vif_uuid]

--- a/neutron/plugins/openvswitch/agent/ovs_neutron_agent.py
+++ b/neutron/plugins/openvswitch/agent/ovs_neutron_agent.py
@@ -42,6 +42,7 @@ from neutron.common import legacy
 from neutron.common import topics
 from neutron.common import utils as q_utils
 from neutron import context
+from neutron.openstack.common import jsonutils
 from neutron.openstack.common import log as logging
 from neutron.openstack.common import loopingcall
 from neutron.openstack.common.rpc import dispatcher
@@ -810,6 +811,23 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
         cur_ports = self.int_br.get_vif_port_set()
         self.int_br_device_count = len(cur_ports)
         port_info = {'current': cur_ports}
+        # Look for ports that are missing a VLAN tag that should have one
+        if cfg.CONF.OVS.tenant_network_type in [constants.TYPE_VLAN,
+                                                constants.TYPE_VXLAN,
+                                                constants.TYPE_GRE]:
+            tags = self.int_br.get_port_tag_dict()
+            for port in tags.keys():
+                if isinstance(tags[port], list) and (
+                        port.startswith('qg-') or
+                        port.startswith('qr-') or
+                        port.startswith('tap')):
+                    port_info['added'] = {self.int_br.db_get_map(
+                        "Interface", port, "external_ids")['iface-id']}
+
+                    LOG.info(_("Forcing resync for port %s"), port)
+
+                    return port_info
+
         if updated_ports:
             # Some updated ports might have been removed in the
             # meanwhile, and therefore should not be processed.


### PR DESCRIPTION
This is an adaptation of a patch sourced from AT&T to work with the current version of the OVS agent code (https://gist.githubusercontent.com/alanmeadows/fcfb6a4f9596fe37341c/raw/00df709b468fe65815bf6fc5e1623958f5642e4a/gistfile1.txt).

It scans for ports that have no VLAN tag but should and forces a resyc for said port. I based this check on checking the current tenant_network_type and execute when type is VLAN, VXLAN or GRE. I am not 100% sure if this is entirely correct so please verify. The problem with the original patch is that it assumed a network type that would have vlan tagging and if ran in a flat network, all ports would have a forced resync on each iteration of the RPC loop.

A valid test for this is to remove the vlan tag from an existing port.

```
    ovs-vsctl show
    ovs-vsctl remove Port <port name> tag 1
```

Where port name starts with "qg-", "qr-" or "tap". The port should be picked up and re-synced with the current vlan tag reappearing.  

**Commit**
- Initial refactoring of a patch authored by AT&T
- Moved get_port_tag_dict to ovs_lib.py which seemed more appropriate.
- Now only examining a port to look for a tag on specific types of tenant networks.
- Added tenant_network_type to the initialization of OVSNeutronAgent
- Now checking for specific tenant network types before looking for vlan tags.
- Now setting self.tenant_network_type from the OVS config.
- Adjusted unit test.
- Adjusted log message when port in forced to resync.
- Clean up test values.
- Removed incorrect spacing.

Closes-rally-bug: DE734
