### PR TITLE
Block subnet gateway IP to be used as LB VIP

### DIFF
--- a/neutron/db/loadbalancer/loadbalancer_db.py
+++ b/neutron/db/loadbalancer/loadbalancer_db.py
@@ -311,7 +311,8 @@ class LoadBalancerPluginDb(LoadBalancerPluginBase,
             fixed_ip = {'subnet_id': subnet['id']}
             if ip_address and ip_address != attributes.ATTR_NOT_SPECIFIED:
                 fixed_ip['ip_address'] = ip_address
-
+                if subnet['gateway_ip'] is not None and subnet['gateway_ip'] == ip_address:
+                    raise q_exc.IpAddressInUse(net_id=subnet['network_id'], ip_address=ip_address)
             port_data = {
                 'tenant_id': vip_db.tenant_id,
                 'name': 'vip-' + vip_db.id,

--- a/neutron/tests/unit/db/loadbalancer/test_db_loadbalancer.py
+++ b/neutron/tests/unit/db/loadbalancer/test_db_loadbalancer.py
@@ -449,6 +449,10 @@ class TestLoadBalancer(LoadBalancerPluginDbTestCase):
             with testtools.ExpectedException(webob.exc.HTTPClientError):
                 self.test_create_vip(pool=pool, protocol='HTTP')
 
+    def test_create_vip_with_gateway_ip(self):
+        with testtools.ExpectedException(webob.exc.HTTPClientError):
+            self.test_create_vip(address='10.0.0.1')
+
     def test_update_vip_with_protocol_mismatch(self):
         with self.pool(protocol='TCP') as pool:
             with self.vip(protocol='HTTP') as vip:


### PR DESCRIPTION
This fix raises an IpAddressInUse exception when subnet gateway IP is assigned
to a loadbalancer VIP.

For a subnet gateway IP address that is not associated with a port, neutron
allows user to set this gateway IP as a loadbalancer VIP.  If this gateway IP
is used by an external router, both the router and LB VIP uses the same IP
address, and traffic may not reach its intended destination, which poses a
security risk.

Closes-rally-bug: rally-bug DE771
Implements: rally-task TA7076
Not-in-upstream: true
