### PR TITLE
Fix dhcp agent debug logging bug

### DIFF
--- a/neutron/db/db_base_plugin_v2.py
+++ b/neutron/db/db_base_plugin_v2.py
@@ -411,7 +411,7 @@ class NeutronDbPluginV2(neutron_plugin_base_v2.NeutronPluginBaseV2,
                 orm.noload('available_ranges')).with_lockmode('update')
         for subnet in sorted(subnets):
             LOG.debug(_("Rebuilding availability ranges for subnet %s")
-                      % subnet)
+                      % subnet['id'])
 
             # Create a set of all currently allocated addresses
             ip_qry_results = ip_qry.filter_by(subnet_id=subnet['id'])


### PR DESCRIPTION
The DHCP agent calling rebuild availability ranges will throw
"Returning exception Parent instance <IPAllocationPool at 0x4ab9b90>
is not bound to a Session; lazy load operation of attribute 'subnet'
 cannot proceed to caller" exception.

This fix returns just logs the subnet id, as we do not have the db session
to query for the entire IPAllocationPool object.

Fixes: rally-defect DE975
Not-in-upstream: true
