### PR TITLE
Handle IPAddressGenerationFailure during get_dhcp_port

### DIFF
--- a/neutron/db/dhcp_rpc_base.py
+++ b/neutron/db/dhcp_rpc_base.py
@@ -168,7 +168,8 @@ class DhcpRpcCallbackMixin(object):
                 retval = plugin.create_port(context, dict(port=port_dict))
             except (db_exc.DBError,
                     n_exc.NetworkNotFound,
-                    n_exc.SubnetNotFound) as e:
+                    n_exc.SubnetNotFound,
+                    n_exc.IpAddressGenerationFailure) as e:
                 LOG.warn(_("Port for network %(net_id)s could not be created: "
                            "%(reason)s") % {"net_id": network_id, 'reason': e})
                 return

--- a/neutron/tests/unit/test_db_rpc_base.py
+++ b/neutron/tests/unit/test_db_rpc_base.py
@@ -138,6 +138,10 @@ class TestDhcpRpcCallackMixin(base.BaseTestCase):
         self._test_get_dhcp_port_with_failures(
             raise_create_port=n_exc.SubnetNotFound(subnet_id='b'))
 
+    def test_get_dhcp_port_catch_ip_generation_failure_on_create_port(self):
+        self._test_get_dhcp_port_with_failures(
+            raise_create_port=n_exc.IpAddressGenerationFailure(net_id='a'))
+
     def _test_get_dhcp_port_create_new(self, update_port=None):
         self.plugin.get_network.return_value = dict(tenant_id='tenantid')
         create_spec = dict(tenant_id='tenantid', device_id='devid',


### PR DESCRIPTION
If a network/subnet is deleted while the dhcp agent is trying
to get/create a dhcp port for that network, the exception
will be raised because no IP Allocation Range is available.

However, this particular failure mode causes just noise, because
the dhcp agent can cope with it without problems.

A follow-up patch will deal with the other exception traces during
create_dhcp_port

Partial-bug: #1253344
Partial-rally-bug: DE1004
Upstream-Review: https://review.openstack.org/#/c/57775/
Backported-from: icehouse
Change-Id: I7fe35455ce905daa22ff96367e120864a7d3fb92
