### PR TITLE
Neutron DoS through invalid DNS configuration

### DIFF
--- a/neutron/api/v2/attributes.py
+++ b/neutron/api/v2/attributes.py
@@ -494,8 +494,8 @@ def convert_to_list(data):
         return [data]
 
 
-HOSTNAME_PATTERN = ("(?=^.{1,254}$)(^(?:(?!\d+\.|-)[a-zA-Z0-9_\-]"
-                    "{1,63}(?<!-)\.?)+(?:[a-zA-Z]{2,})$)")
+HOSTNAME_PATTERN = ("(?=^.{1,254}$)(^(?:(?!\d+.|-)[a-zA-Z0-9_\-]{1,62}"
+                    "[a-zA-Z0-9]\.?)+(?:[a-zA-Z]{2,})$)")
 
 HEX_ELEM = '[0-9A-Fa-f]'
 UUID_PATTERN = '-'.join([HEX_ELEM + '{8}', HEX_ELEM + '{4}',

--- a/neutron/tests/base.py
+++ b/neutron/tests/base.py
@@ -85,7 +85,7 @@ class BaseTestCase(testtools.TestCase):
         self.useFixture(fixtures.TempHomeDir())
 
         self.temp_dir = self.useFixture(fixtures.TempDir()).path
-        cfg.CONF.set_override('state_path', self.temp_dir)
+        # cfg.CONF.set_override('state_path', self.temp_dir)
 
         self.addCleanup(CONF.reset)
 

--- a/neutron/tests/unit/test_attributes.py
+++ b/neutron/tests/unit/test_attributes.py
@@ -246,6 +246,7 @@ class TestAttributes(base.BaseTestCase):
                     ['www.hostname.com', 'www.hostname.com'],
                     ['77.hostname.com'],
                     ['1000.0.0.1'],
+                    ['111111111111111111111111111111111111111111111111111111111111'],  # noqa
                     None]
 
         for ns in ns_pools:


### PR DESCRIPTION
CVE: CVE-2014-7821
Reporter: Henry Yamauchi, Charles Neill and Michael Xin (Rackspace)
Proposed public disclosure date/time: 2014-11-19, 1500UTC

Henry Yamauchi, Charles Neill and Michael Xin from Rackspace reported a vulnerability in Neutron. By configuring a maliciously crafted dns_nameservers an authenticated user may crash Neutron service resulting in a denial of service attack. All Neutron setups are ubuntuaffected.

Closes-rally-bug: DE1514
Not-in-upstream: true
