### PR TITLE
Make timeout for ovs-vsctl configurable

### DIFF
--- a/etc/dhcp_agent.ini
+++ b/etc/dhcp_agent.ini
@@ -78,3 +78,7 @@
 # you are sure that your version of iproute does not suffer from the problem.
 # If True, namespaces will be deleted when a dhcp server is disabled.
 # dhcp_delete_namespaces = False
+
+# Timeout for ovs-vsctl commands.
+# If the timeout expires, ovs commands will fail with ALARMCLOCK error.
+# ovs_vsctl_timeout = 10

--- a/etc/l3_agent.ini
+++ b/etc/l3_agent.ini
@@ -73,3 +73,7 @@
 # you are sure that your version of iproute does not suffer from the problem.
 # If True, namespaces will be deleted when a router is destroyed.
 # router_delete_namespaces = False
+
+# Timeout for ovs-vsctl commands.
+# If the timeout expires, ovs commands will fail with ALARMCLOCK error.
+# ovs_vsctl_timeout = 10

--- a/neutron/agent/dhcp_agent.py
+++ b/neutron/agent/dhcp_agent.py
@@ -25,6 +25,7 @@ from neutron.agent.common import config
 from neutron.agent.linux import dhcp
 from neutron.agent.linux import external_process
 from neutron.agent.linux import interface
+from neutron.agent.linux import ovs_lib  # noqa
 from neutron.agent import rpc as agent_rpc
 from neutron.common import constants
 from neutron.common import exceptions

--- a/neutron/agent/l3_agent.py
+++ b/neutron/agent/l3_agent.py
@@ -26,6 +26,7 @@ from neutron.agent.linux import external_process
 from neutron.agent.linux import interface
 from neutron.agent.linux import ip_lib
 from neutron.agent.linux import iptables_manager
+from neutron.agent.linux import ovs_lib  # noqa
 from neutron.agent.linux import utils
 from neutron.agent import rpc as agent_rpc
 from neutron.common import constants as l3_constants

--- a/neutron/plugins/ryu/common/config.py
+++ b/neutron/plugins/ryu/common/config.py
@@ -17,7 +17,7 @@
 from oslo.config import cfg
 
 from neutron.agent.common import config
-
+from neutron.agent.linux import ovs_lib  # noqa
 
 ovs_opts = [
     cfg.StrOpt('integration_bridge', default='br-int',


### PR DESCRIPTION
Backport from icehouse to update the ovs-vsctl timeout:

Implements: DE1240
Upstream-Review: https://review.openstack.org/#/c/61105/
