### PR TITLE
Do not support IPv6 in Havana

### DIFF
--- a/neutron/tests/unit/test_iptables_firewall.py
+++ b/neutron/tests/unit/test_iptables_firewall.py
@@ -420,6 +420,7 @@ class IptablesFirewallTestCase(base.BaseTestCase):
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv6_ingress(self):
+        self.skipTest("Do not support IPv6")
         rule = {'ethertype': 'IPv6',
                 'direction': 'ingress'}
         ingress = call.add_rule('ifake_dev', '-j RETURN')
@@ -427,6 +428,7 @@ class IptablesFirewallTestCase(base.BaseTestCase):
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv6_ingress_prefix(self):
+        self.skipTest("Do not support IPv6")
         prefix = FAKE_PREFIX['IPv6']
         rule = {'ethertype': 'IPv6',
                 'direction': 'ingress',
@@ -436,6 +438,7 @@ class IptablesFirewallTestCase(base.BaseTestCase):
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv6_ingress_tcp(self):
+        self.skipTest("Do not support IPv6")
         rule = {'ethertype': 'IPv6',
                 'direction': 'ingress',
                 'protocol': 'tcp'}
@@ -444,6 +447,7 @@ class IptablesFirewallTestCase(base.BaseTestCase):
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv6_ingress_tcp_prefix(self):
+        self.skipTest("Do not support IPv6")
         prefix = FAKE_PREFIX['IPv6']
         rule = {'ethertype': 'IPv6',
                 'direction': 'ingress',
@@ -455,6 +459,7 @@ class IptablesFirewallTestCase(base.BaseTestCase):
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv6_ingress_tcp_port(self):
+        self.skipTest("Do not support IPv6")
         rule = {'ethertype': 'IPv6',
                 'direction': 'ingress',
                 'protocol': 'tcp',
@@ -466,6 +471,7 @@ class IptablesFirewallTestCase(base.BaseTestCase):
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv6_ingress_icmp(self):
+        self.skipTest("Do not support IPv6")
         rule = {'ethertype': 'IPv6',
                 'direction': 'ingress',
                 'protocol': 'icmp'}
@@ -474,6 +480,7 @@ class IptablesFirewallTestCase(base.BaseTestCase):
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv6_ingress_icmp_prefix(self):
+        self.skipTest("Do not support IPv6")
         prefix = FAKE_PREFIX['IPv6']
         rule = {'ethertype': 'IPv6',
                 'direction': 'ingress',
@@ -485,6 +492,7 @@ class IptablesFirewallTestCase(base.BaseTestCase):
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv6_ingress_tcp_mport(self):
+        self.skipTest("Do not support IPv6")
         rule = {'ethertype': 'IPv6',
                 'direction': 'ingress',
                 'protocol': 'tcp',
@@ -497,6 +505,7 @@ class IptablesFirewallTestCase(base.BaseTestCase):
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv6_ingress_tcp_mport_prefix(self):
+        self.skipTest("Do not support IPv6")
         prefix = FAKE_PREFIX['IPv6']
         rule = {'ethertype': 'IPv6',
                 'direction': 'ingress',
@@ -512,6 +521,7 @@ class IptablesFirewallTestCase(base.BaseTestCase):
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv6_ingress_udp(self):
+        self.skipTest("Do not support IPv6")
         rule = {'ethertype': 'IPv6',
                 'direction': 'ingress',
                 'protocol': 'udp'}
@@ -520,6 +530,7 @@ class IptablesFirewallTestCase(base.BaseTestCase):
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv6_ingress_udp_prefix(self):
+        self.skipTest("Do not support IPv6")
         prefix = FAKE_PREFIX['IPv6']
         rule = {'ethertype': 'IPv6',
                 'direction': 'ingress',
@@ -531,6 +542,7 @@ class IptablesFirewallTestCase(base.BaseTestCase):
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv6_ingress_udp_port(self):
+        self.skipTest("Do not support IPv6")
         rule = {'ethertype': 'IPv6',
                 'direction': 'ingress',
                 'protocol': 'udp',
@@ -542,6 +554,7 @@ class IptablesFirewallTestCase(base.BaseTestCase):
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv6_ingress_udp_mport(self):
+        self.skipTest("Do not support IPv6")
         rule = {'ethertype': 'IPv6',
                 'direction': 'ingress',
                 'protocol': 'udp',
@@ -554,6 +567,7 @@ class IptablesFirewallTestCase(base.BaseTestCase):
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv6_ingress_udp_mport_prefix(self):
+        self.skipTest("Do not support IPv6")
         prefix = FAKE_PREFIX['IPv6']
         rule = {'ethertype': 'IPv6',
                 'direction': 'ingress',
@@ -569,6 +583,7 @@ class IptablesFirewallTestCase(base.BaseTestCase):
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv6_egress(self):
+        self.skipTest("Do not support IPv6")
         rule = {'ethertype': 'IPv6',
                 'direction': 'egress'}
         egress = call.add_rule('ofake_dev', '-j RETURN')
@@ -576,6 +591,7 @@ class IptablesFirewallTestCase(base.BaseTestCase):
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv6_egress_prefix(self):
+        self.skipTest("Do not support IPv6")
         prefix = FAKE_PREFIX['IPv6']
         rule = {'ethertype': 'IPv6',
                 'direction': 'egress',
@@ -585,6 +601,7 @@ class IptablesFirewallTestCase(base.BaseTestCase):
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv6_egress_tcp(self):
+        self.skipTest("Do not support IPv6")
         rule = {'ethertype': 'IPv6',
                 'direction': 'egress',
                 'protocol': 'tcp'}
@@ -593,6 +610,7 @@ class IptablesFirewallTestCase(base.BaseTestCase):
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv6_egress_tcp_prefix(self):
+        self.skipTest("Do not support IPv6")
         prefix = FAKE_PREFIX['IPv6']
         rule = {'ethertype': 'IPv6',
                 'direction': 'egress',
@@ -604,6 +622,7 @@ class IptablesFirewallTestCase(base.BaseTestCase):
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv6_egress_icmp(self):
+        self.skipTest("Do not support IPv6")
         rule = {'ethertype': 'IPv6',
                 'direction': 'egress',
                 'protocol': 'icmp'}
@@ -612,6 +631,7 @@ class IptablesFirewallTestCase(base.BaseTestCase):
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv6_egress_icmp_prefix(self):
+        self.skipTest("Do not support IPv6")
         prefix = FAKE_PREFIX['IPv6']
         rule = {'ethertype': 'IPv6',
                 'direction': 'egress',
@@ -623,6 +643,7 @@ class IptablesFirewallTestCase(base.BaseTestCase):
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv6_egress_tcp_port(self):
+        self.skipTest("Do not support IPv6")
         rule = {'ethertype': 'IPv6',
                 'direction': 'egress',
                 'protocol': 'tcp',
@@ -634,6 +655,7 @@ class IptablesFirewallTestCase(base.BaseTestCase):
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv6_egress_tcp_mport(self):
+        self.skipTest("Do not support IPv6")
         rule = {'ethertype': 'IPv6',
                 'direction': 'egress',
                 'protocol': 'tcp',
@@ -646,6 +668,7 @@ class IptablesFirewallTestCase(base.BaseTestCase):
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv6_egress_tcp_mport_prefix(self):
+        self.skipTest("Do not support IPv6")
         prefix = FAKE_PREFIX['IPv6']
         rule = {'ethertype': 'IPv6',
                 'direction': 'egress',
@@ -661,6 +684,7 @@ class IptablesFirewallTestCase(base.BaseTestCase):
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv6_egress_udp(self):
+        self.skipTest("Do not support IPv6")
         rule = {'ethertype': 'IPv6',
                 'direction': 'egress',
                 'protocol': 'udp'}
@@ -669,6 +693,7 @@ class IptablesFirewallTestCase(base.BaseTestCase):
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv6_egress_udp_prefix(self):
+        self.skipTest("Do not support IPv6")
         prefix = FAKE_PREFIX['IPv6']
         rule = {'ethertype': 'IPv6',
                 'direction': 'egress',
@@ -680,6 +705,7 @@ class IptablesFirewallTestCase(base.BaseTestCase):
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv6_egress_udp_port(self):
+        self.skipTest("Do not support IPv6")
         rule = {'ethertype': 'IPv6',
                 'direction': 'egress',
                 'protocol': 'udp',
@@ -691,6 +717,7 @@ class IptablesFirewallTestCase(base.BaseTestCase):
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv6_egress_udp_mport(self):
+        self.skipTest("Do not support IPv6")
         rule = {'ethertype': 'IPv6',
                 'direction': 'egress',
                 'protocol': 'udp',
@@ -703,6 +730,7 @@ class IptablesFirewallTestCase(base.BaseTestCase):
         self._test_prepare_port_filter(rule, ingress, egress)
 
     def test_filter_ipv6_egress_udp_mport_prefix(self):
+        self.skipTest("Do not support IPv6")
         prefix = FAKE_PREFIX['IPv6']
         rule = {'ethertype': 'IPv6',
                 'direction': 'egress',

--- a/neutron/tests/unit/test_security_groups_rpc.py
+++ b/neutron/tests/unit/test_security_groups_rpc.py
@@ -287,6 +287,7 @@ class SGServerRpcCallBackMixinTestCase(test_sg.SecurityGroupDBTestCase):
                 self._delete('ports', port_id2)
 
     def test_security_group_rules_for_devices_ipv6_ingress(self):
+        self.skipTest("Do not support IPv6")
         fake_prefix = test_fw.FAKE_PREFIX[const.IPv6]
         with self.network() as n:
             with nested(self.subnet(n,
@@ -346,6 +347,7 @@ class SGServerRpcCallBackMixinTestCase(test_sg.SecurityGroupDBTestCase):
                 self._delete('ports', port_id1)
 
     def test_security_group_rules_for_devices_ipv6_egress(self):
+        self.skipTest("Do not support IPv6")
         fake_prefix = test_fw.FAKE_PREFIX[const.IPv6]
         with self.network() as n:
             with nested(self.subnet(n,
@@ -407,6 +409,7 @@ class SGServerRpcCallBackMixinTestCase(test_sg.SecurityGroupDBTestCase):
                 self._delete('ports', port_id1)
 
     def test_security_group_rules_for_devices_ipv6_source_group(self):
+        self.skipTest("Do not support IPv6")
         fake_prefix = test_fw.FAKE_PREFIX[const.IPv6]
         with self.network() as n:
             with nested(self.subnet(n,

--- a/neutron/tests/unit/test_wsgi.py
+++ b/neutron/tests/unit/test_wsgi.py
@@ -64,6 +64,7 @@ class TestWSGIServer(base.BaseTestCase):
         launcher.wait.assert_called_once_with()
 
     def test_start_random_port_with_ipv6(self):
+        self.skipTest("Do not support IPv6")
         server = wsgi.Server("test_random_port")
         server.start(None, 0, host="::1")
         self.assertEqual("::1", server.host)
@@ -72,6 +73,7 @@ class TestWSGIServer(base.BaseTestCase):
         server.wait()
 
     def test_ipv6_listen_called_with_scope(self):
+        self.skipTest("Do not support IPv6")
         server = wsgi.Server("test_app")
 
         with mock.patch.object(wsgi.eventlet, 'listen') as mock_listen:


### PR DESCRIPTION
Havana is not IPv6 ready.
Users are not allowed to configure IPv6 network from Horizon or CLI.

Implements: rally-user-story US6909
Not-in-upstream: true
