### PR TITLE
ExtraRoute: fix _get_extra_routes_by_router_id()

### DIFF
--- a/neutron/db/extraroute_db.py
+++ b/neutron/db/extraroute_db.py
@@ -147,7 +147,7 @@ class ExtraRoute_db_mixin(l3_db.L3_NAT_db_mixin):
 
     def _get_extra_routes_by_router_id(self, context, id):
         query = context.session.query(RouterRoute)
-        query.filter(RouterRoute.router_id == id)
+        query = query.filter_by(router_id=id)
         return self._make_extra_route_list(query)
 
     def get_router(self, context, id, fields=None):

--- a/neutron/tests/unit/test_extension_extraroute.py
+++ b/neutron/tests/unit/test_extension_extraroute.py
@@ -144,6 +144,33 @@ class ExtraRouteDBTestCaseBase(object):
                     self._routes_update_cleanup(p['port']['id'],
                                                 None, r['router']['id'], [])
 
+    def test_routes_update_for_multiple_routers(self):
+        routes1 = [{'destination': '135.207.0.0/16',
+                   'nexthop': '10.0.0.3'}]
+        routes2 = [{'destination': '12.0.0.0/8',
+                   'nexthop': '10.0.0.4'}]
+        with contextlib.nested(
+                self.router(),
+                self.router(),
+                self.subnet(cidr='10.0.0.0/24')) as (r1, r2, s):
+            with contextlib.nested(
+                    self.port(subnet=s, no_delete=True),
+                    self.port(subnet=s, no_delete=True)) as (p1, p2):
+                body = self._routes_update_prepare(r1['router']['id'],
+                                                   None, p1['port']['id'],
+                                                   routes1)
+                self.assertEqual(body['router']['routes'], routes1)
+
+                body = self._routes_update_prepare(r2['router']['id'],
+                                                   None, p2['port']['id'],
+                                                   routes2)
+                self.assertEqual(body['router']['routes'], routes2)
+
+                self._routes_update_cleanup(p1['port']['id'],
+                                            None, r1['router']['id'], [])
+                self._routes_update_cleanup(p2['port']['id'],
+                                            None, r2['router']['id'], [])
+
     def test_router_update_delete_routes(self):
         routes_orig = [{'destination': '135.207.0.0/16',
                         'nexthop': '10.0.1.3'},


### PR DESCRIPTION
router_id filter wasn't properly applied to the query
so the func returned all extra routes of all routers.

Closes-Bug: #1248219
Change-Id: I77733ee7994c8fccbbc966ccabd83b8fe4def8d5
Upstream-Review: https://review.openstack.org/#/c/55532/2
Backported-from: icehouse
Closes-rally-bug: DE1742
