### PR TITLE
Backport https://review.openstack.org/#/c/108272/

### DIFF
--- a/etc/neutron/rootwrap.d/dhcp.filters
+++ b/etc/neutron/rootwrap.d/dhcp.filters
@@ -9,7 +9,7 @@
 [Filters]
 
 # dhcp-agent
-dnsmasq: EnvFilter, dnsmasq, root, NEUTRON_NETWORK_ID=
+dnsmasq: EnvFilter, dnsmasq, root, HOSTS_FILE=
 # dhcp-agent uses kill as well, that's handled by the generic KillFilter
 # it looks like these are the only signals needed, per
 # neutron/agent/linux/dhcp.py

--- a/neutron/tests/unit/test_linux_dhcp.py
+++ b/neutron/tests/unit/test_linux_dhcp.py
@@ -669,7 +669,7 @@ class TestDnsmasq(TestBase):
             'exec',
             'qdhcp-ns',
             'env',
-            'NEUTRON_NETWORK_ID=%s' % network.id,
+            'HOSTS_FILE=/dhcp/%s/host' % network.id,
             'dnsmasq',
             '--no-hosts',
             '--no-resolv',
@@ -681,7 +681,9 @@ class TestDnsmasq(TestBase):
             '--dhcp-hostsfile=/dhcp/%s/host' % network.id,
             '--addn-hosts=/dhcp/%s/addn_hosts' % network.id,
             '--dhcp-optsfile=/dhcp/%s/opts' % network.id,
-            '--dhcp-leasefile=/dhcp/%s/lease' % network.id]
+            '--dhcp-script=/usr/local/bin/'
+            'neutron-dhcp-agent-dnsmasq-lease-init',
+            '--leasefile-ro']
 
         expected.extend(
             '--dhcp-range=set:tag%d,%s,static,86400s' %

--- a/setup.cfg
+++ b/setup.cfg
@@ -83,6 +83,7 @@ console_scripts =
     neutron-db-manage = neutron.db.migration.cli:main
     neutron-debug = neutron.debug.shell:main
     neutron-dhcp-agent = neutron.agent.dhcp_agent:main
+    neutron-dhcp-agent-dnsmasq-lease-init = neutron.agent.linux.dhcp:Dnsmasq.lease_init
     neutron-hyperv-agent = neutron.plugins.hyperv.agent.hyperv_neutron_agent:main
     neutron-l3-agent = neutron.agent.l3_agent:main
     neutron-lbaas-agent = neutron.services.loadbalancer.drivers.haproxy.agent:main


### PR DESCRIPTION
This should adddress the DHCPNAK issue we are seeing
in Havan (and likely Icehouse as well).

This code will cause dnsmasq to execute dhcp-script
which will readin the hosts files and create leases
for everything in them, thus elininating the DHCPNAK
which comes from the dnsmasq process no longer knowing
about the lease.

Closes-rally-bug: DE1821
Upstream-Review: https://review.openstack.org/#/c/108272/5
Not-in-upstream: true
