### PR TITLE
Add support for mulitple RPC workers for OVS and ML2 plugin

### DIFF
--- a/neutron/neutron_plugin_base_v2.py
+++ b/neutron/neutron_plugin_base_v2.py
@@ -336,3 +336,18 @@ class NeutronPluginBaseV2(object):
                   defined plugin API.
         """
         raise NotImplementedError
+
+    def rpc_workers_supported(self):
+        """Return whether the plugin supports multiple RPC workers.
+
+        A plugin that supports multiple RPC workers should override the
+        start_rpc_listener method to ensure that this method returns True and
+        that start_rpc_listener is called at the appropriate time.
+        Alternately, a plugin can override this method to customize detection
+        of support for multiple rpc workers
+
+        .. note:: this method is optional, as it was not part of the originally
+                  defined plugin API.
+        """
+        return (self.__class__.start_rpc_listener !=
+                NeutronPluginBaseV2.start_rpc_listener)

--- a/neutron/service.py
+++ b/neutron/service.py
@@ -25,7 +25,6 @@ from neutron.common import config
 from neutron.common import legacy
 from neutron import context
 from neutron import manager
-from neutron import neutron_plugin_base_v2
 from neutron.openstack.common.db.sqlalchemy import session
 from neutron.openstack.common import excutils
 from neutron.openstack.common import importutils
@@ -144,10 +143,9 @@ def serve_rpc():
 
     # If 0 < rpc_workers then start_rpc_listener would be called in a
     # subprocess and we cannot simply catch the NotImplementedError.  It is
-    # simpler to check this up front by testing whether the plugin overrides
-    # start_rpc_listener.
-    base = neutron_plugin_base_v2.NeutronPluginBaseV2
-    if plugin.__class__.start_rpc_listener == base.start_rpc_listener:
+    # simpler to check this up front by testing whether the plugin supports
+    # multiple RPC workers.
+    if not plugin.rpc_workers_supported():
         LOG.debug(_("Active plugin doesn't implement start_rpc_listener"))
         if 0 < cfg.CONF.rpc_workers:
             msg = _("'rpc_workers = %d' ignored because start_rpc_listener "


### PR DESCRIPTION
OVS and ML2 plugin needs a fix to support multiple RPC workers properly
because a plugin which supports multiple RPC workers cannot
initialize RPC connections at plugin initialization.

Partial-Bug: #1300570
Closes-Bug: 1303933
Closes-rally-bug: DE1977
Upstream-Review: https://review.openstack.org/#/c/85774
Upstream-Review: https://review.openstack.org/#/c/90011
Not-in-upstream: True
