### PR TITLE
Bugs/de1977 tests

### DIFF
--- a/neutron/tests/unit/openvswitch/test_ovs_lib.py
+++ b/neutron/tests/unit/openvswitch/test_ovs_lib.py
@@ -598,7 +598,7 @@ class OVS_Lib_Test(base.BaseTestCase):
         br = 'br-int'
         root_helper = 'sudo'
         exp_timeout_str = self._build_timeout_opt(exp_timeout)
-	utils.execute(["ovs-vsctl", exp_timeout_str, "iface-to-br", iface],
+        utils.execute(["ovs-vsctl", exp_timeout_str, "iface-to-br", iface],
                       root_helper=root_helper).AndReturn('br-int')
 
         self.mox.ReplayAll()
@@ -650,7 +650,7 @@ class OVS_Lib_Test(base.BaseTestCase):
         bridges = ['br-int', 'br-ex']
         root_helper = 'sudo'
         timeout_str = self._build_timeout_opt(exp_timeout)
-	utils.execute(["ovs-vsctl", timeout_str, "list-br"],
+        utils.execute(["ovs-vsctl", timeout_str, "list-br"],
                       root_helper=root_helper).AndReturn('br-int\nbr-ex\n')
 
         self.mox.ReplayAll()

--- a/neutron/tests/unit/openvswitch/test_ovs_lib.py
+++ b/neutron/tests/unit/openvswitch/test_ovs_lib.py
@@ -17,6 +17,7 @@
 
 import mock
 import mox
+from oslo.config import cfg
 import testtools
 
 from neutron.agent.linux import ovs_lib
@@ -596,7 +597,8 @@ class OVS_Lib_Test(base.BaseTestCase):
         iface = 'tap0'
         br = 'br-int'
         root_helper = 'sudo'
-        utils.execute(["ovs-vsctl", self.TO, "iface-to-br", iface],
+        exp_timeout_str = self._build_timeout_opt(exp_timeout)
+	utils.execute(["ovs-vsctl", exp_timeout_str, "iface-to-br", iface],
                       root_helper=root_helper).AndReturn('br-int')
 
         self.mox.ReplayAll()
@@ -647,7 +649,8 @@ class OVS_Lib_Test(base.BaseTestCase):
     def _test_get_bridges(self, exp_timeout=None):
         bridges = ['br-int', 'br-ex']
         root_helper = 'sudo'
-        utils.execute(["ovs-vsctl", self.TO, "list-br"],
+        timeout_str = self._build_timeout_opt(exp_timeout)
+	utils.execute(["ovs-vsctl", timeout_str, "list-br"],
                       root_helper=root_helper).AndReturn('br-int\nbr-ex\n')
 
         self.mox.ReplayAll()

--- a/neutron/tests/unit/openvswitch/test_ovs_security_group.py
+++ b/neutron/tests/unit/openvswitch/test_ovs_security_group.py
@@ -68,6 +68,12 @@ class TestOpenvswitchSGServerRpcCallBackXML(
 class TestOpenvswitchSecurityGroups(OpenvswitchSecurityGroupsTestCase,
                                     test_sg.TestSecurityGroups,
                                     test_sg_rpc.SGNotificationTestMixin):
+
+    def setUp(self):
+	super(TestOpenvswitchSecurityGroups, self).setUp()
+	plugin = manager.NeutronManager.get_plugin()
+	plugin.start_rpc_listener()
+
     def test_security_group_get_port_from_device(self):
         with self.network() as n:
             with self.subnet(n):


### PR DESCRIPTION
Updated ovs tests to start the RPC listener. 
Also fixed existing broken ovs_lib tests that were failing.

Partial-bug: DE1977, DE1240
Not-in-upstream: True
