### PR TITLE
Update OVS tests to support starting rpc_workers and fix ovs_lib tests

### DIFF
--- a/neutron/tests/unit/openvswitch/test_ovs_lib.py
+++ b/neutron/tests/unit/openvswitch/test_ovs_lib.py
@@ -24,7 +24,7 @@ from neutron.agent.linux import utils
 from neutron.openstack.common import jsonutils
 from neutron.openstack.common import uuidutils
 from neutron.tests import base
-
+from oslo.config import cfg
 
 class TestBaseOVS(base.BaseTestCase):
 
@@ -596,7 +596,8 @@ class OVS_Lib_Test(base.BaseTestCase):
         iface = 'tap0'
         br = 'br-int'
         root_helper = 'sudo'
-        utils.execute(["ovs-vsctl", self.TO, "iface-to-br", iface],
+        exp_timeout_str = self._build_timeout_opt(exp_timeout)
+        utils.execute(["ovs-vsctl", exp_timeout_str, "iface-to-br", iface],
                       root_helper=root_helper).AndReturn('br-int')
 
         self.mox.ReplayAll()
@@ -647,7 +648,8 @@ class OVS_Lib_Test(base.BaseTestCase):
     def _test_get_bridges(self, exp_timeout=None):
         bridges = ['br-int', 'br-ex']
         root_helper = 'sudo'
-        utils.execute(["ovs-vsctl", self.TO, "list-br"],
+        timeout_str = self._build_timeout_opt(exp_timeout)
+        utils.execute(["ovs-vsctl", timeout_str, "list-br"],
                       root_helper=root_helper).AndReturn('br-int\nbr-ex\n')
 
         self.mox.ReplayAll()

--- a/neutron/tests/unit/openvswitch/test_ovs_security_group.py
+++ b/neutron/tests/unit/openvswitch/test_ovs_security_group.py
@@ -68,6 +68,12 @@ class TestOpenvswitchSGServerRpcCallBackXML(
 class TestOpenvswitchSecurityGroups(OpenvswitchSecurityGroupsTestCase,
                                     test_sg.TestSecurityGroups,
                                     test_sg_rpc.SGNotificationTestMixin):
+
+    def setUp(self):
+        super(TestOpenvswitchSecurityGroups, self).setUp()
+        plugin = manager.NeutronManager.get_plugin()
+        plugin.start_rpc_listener()
+
     def test_security_group_get_port_from_device(self):
         with self.network() as n:
             with self.subnet(n):


### PR DESCRIPTION
Updated ovs tests to start the RPC listener.
Also fixed existing broken ovs_lib tests that were failing.

Partial-bug: DE1977, DE1240
Not-in-upstream: True
