### PR TITLE
Haproxy driver should respect vip/pool admin state

### DIFF
--- a/neutron/services/loadbalancer/drivers/haproxy/agent_manager.py
+++ b/neutron/services/loadbalancer/drivers/haproxy/agent_manager.py
@@ -241,7 +241,7 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):
         if not device:
             return
         try:
-            self.driver.destroy(pool_id)
+            self.driver.destroy(pool_id, delete_namespace=True)
             self.plugin_rpc.pool_destroyed(pool_id)
         except Exception:
             LOG.exception(_('Unable to destroy device for pool: %s'), pool_id)

--- a/neutron/services/loadbalancer/drivers/haproxy/cfg.py
+++ b/neutron/services/loadbalancer/drivers/haproxy/cfg.py
@@ -110,6 +110,9 @@ def _build_frontend(config):
     if protocol == constants.PROTOCOL_HTTP:
         opts.append('option forwardfor')
 
+    if not config['vip']['admin_state_up']:
+        opts.append('disabled')
+
     return itertools.chain(
         ['frontend %s' % config['vip']['id']],
         ('\t' + o for o in opts)
@@ -144,6 +147,9 @@ def _build_backend(config):
             if _has_http_cookie_persistence(config):
                 server += ' cookie %d' % config['members'].index(member)
             opts.append(server)
+
+    if not config['pool']['admin_state_up']:
+        opts.append('disabled')
 
     return itertools.chain(
         ['backend %s' % config['pool']['id']],

--- a/neutron/tests/unit/services/loadbalancer/drivers/haproxy/test_agent_manager.py
+++ b/neutron/tests/unit/services/loadbalancer/drivers/haproxy/test_agent_manager.py
@@ -292,7 +292,8 @@ class TestManager(base.BaseTestCase):
 
                 self.mgr.destroy_device('pool_id')
                 cache.get_by_pool_id.assert_called_once_with('pool_id')
-                driver.destroy.assert_called_once_with('pool_id')
+                driver.destroy.assert_called_once_with(
+                    'pool_id', delete_namespace=True)
                 self.rpc_mock.pool_destroyed.assert_called_once_with(
                     'pool_id'
                 )

--- a/neutron/tests/unit/services/loadbalancer/drivers/haproxy/test_cfg.py
+++ b/neutron/tests/unit/services/loadbalancer/drivers/haproxy/test_cfg.py
@@ -84,6 +84,7 @@ class TestHaproxyCfg(base.BaseTestCase):
                                },
                                'protocol_port': 80,
                                'connection_limit': 2000,
+                               'admin_state_up': True,
                                },
                        'pool': {'id': 'pool_id'}}
         expected_opts = ['frontend vip_id',
@@ -101,10 +102,16 @@ class TestHaproxyCfg(base.BaseTestCase):
         opts = cfg._build_frontend(test_config)
         self.assertEqual(expected_opts, list(opts))
 
+        test_config['vip']['admin_state_up'] = False
+        expected_opts.append('\tdisabled')
+        opts = cfg._build_frontend(test_config)
+        self.assertEqual(expected_opts, list(opts))
+
     def test_build_backend(self):
         test_config = {'pool': {'id': 'pool_id',
                                 'protocol': 'HTTP',
-                                'lb_method': 'ROUND_ROBIN'},
+                                'lb_method': 'ROUND_ROBIN',
+                                'admin_state_up': True},
                        'members': [{'status': 'ACTIVE',
                                     'admin_state_up': True,
                                     'id': 'member1_id',
@@ -133,6 +140,11 @@ class TestHaproxyCfg(base.BaseTestCase):
                          'check inter 3s fall 4 cookie 0',
                          '\tserver member2_id 10.0.0.4:80 weight 1 '
                          'check inter 3s fall 4 cookie 1']
+        opts = cfg._build_backend(test_config)
+        self.assertEqual(expected_opts, list(opts))
+
+        test_config['pool']['admin_state_up'] = False
+        expected_opts.append('\tdisabled')
         opts = cfg._build_backend(test_config)
         self.assertEqual(expected_opts, list(opts))
 

--- a/neutron/tests/unit/services/loadbalancer/drivers/haproxy/test_namespace_driver.py
+++ b/neutron/tests/unit/services/loadbalancer/drivers/haproxy/test_namespace_driver.py
@@ -99,7 +99,7 @@ class TestHaproxyNSDriver(base.BaseTestCase):
             self.driver.pool_to_port_id['pool_id'] = 'port_id'
             isdir.return_value = True
 
-            self.driver.destroy('pool_id')
+            self.driver.destroy('pool_id', delete_namespace=True)
 
             kill.assert_called_once_with('sudo', '/pool/pid')
             unplug.assert_called_once_with('qlbaas-pool_id', 'port_id')


### PR DESCRIPTION
On vip/pool update when admin_state_up becomes False
haproxy driver should reflect it in the config.
Currently there may be only one vip in the config and
if it is disabled, haproxy process fails to restart with
'[ALERT] 084/045122 (11407) : [haproxy.main()] No enabled
listener found (check the <listen> keywords) ! Exiting.',
and continues running and balancing with old config -
so for this case we need to undeploy loadbalancer.
The patch also moves namespace deletion to delete_pool()
as there is no need to delete/recreate namespace each time
the vip is removed/added or disabled/enabled

Closes-Bug: 1297142
Closes-rally-bug: DE1627
Upstream-Review: https://review.openstack.org/142471
