### PR TITLE
DE1793/DE1853 SG/iptables rule left over under certain race condition.

### DIFF
--- a/neutron/plugins/openvswitch/agent/ovs_neutron_agent.py
+++ b/neutron/plugins/openvswitch/agent/ovs_neutron_agent.py
@@ -1091,6 +1091,10 @@ class OVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin,
                 # have been actually processed.
                 port_info['current'] = (port_info['current'] -
                                         set(skipped_devices))
+
+                # Delete the security group rules for skipped devices
+                self.sg_agent.remove_devices_filter(skipped_devices)
+
             except DeviceListRetrievalError:
                 # Need to resync as there was an error with server
                 # communication.


### PR DESCRIPTION
If devices not be found, delete related sg rules.

If devices cannot be found in br-int, the security
group rules should also be deleted.Do this to avoid
resource leak.

Change-Id: Ib7d8c454e68637295c3741f7832793654a1aaa76
Closes-rally-bug: DE1793/DE1853
Upstream-Review: https://bugs.launchpad.net/neutron/+bug/1403729
Closes-Bug: #1403729
