### PR TITLE
Fix clearing allowed-address-pairs with port_update

### DIFF
--- a/neutron/extensions/allowedaddresspairs.py
+++ b/neutron/extensions/allowedaddresspairs.py
@@ -99,6 +99,7 @@ ADDRESS_PAIRS = 'allowed_address_pairs'
 EXTENDED_ATTRIBUTES_2_0 = {
     'ports': {
         ADDRESS_PAIRS: {'allow_post': True, 'allow_put': True,
+                        'convert_to': attr.convert_none_to_empty_list,
                         'convert_list_to':
                         attr.convert_kvp_list_to_dict,
                         'validate': {'type:validate_allowed_address_pairs':

--- a/neutron/tests/unit/test_extension_allowedaddresspairs.py
+++ b/neutron/tests/unit/test_extension_allowedaddresspairs.py
@@ -322,3 +322,18 @@ class TestAllowedAddressPairs(AllowedAddressPairDBTestCase):
             port = self.deserialize(self.fmt, req.get_response(self.api))
             self.assertEqual(port['port'][addr_pair.ADDRESS_PAIRS], [])
             self._delete('ports', port['port']['id'])
+
+    def test_update_clear_routes_with_None(self):
+        with self.network() as net:
+            address_pairs = [{'mac_address': '00:00:00:00:00:01',
+                              'ip_address': '10.0.0.1'}]
+            res = self._create_port(self.fmt, net['network']['id'],
+                                    arg_list=(addr_pair.ADDRESS_PAIRS,),
+                                    allowed_address_pairs=address_pairs)
+            port = self.deserialize(self.fmt, res)
+            update_port = {'port': {addr_pair.ADDRESS_PAIRS: None}}
+            req = self.new_update_request('ports', update_port,
+                                          port['port']['id'])
+            port = self.deserialize(self.fmt, req.get_response(self.api))
+            self.assertEqual(port['port'][addr_pair.ADDRESS_PAIRS], [])
+            self._delete('ports', port['port']['id'])


### PR DESCRIPTION
By default port-update with action=clear sends None
instead of empty list. This caused error. Used
convert_to in attribute map to convert received
None type to empty list in order to fix this error.

Closes-rally-bug: DE1788
