### PR TITLE
DE897/eed1b7cbdb00a3fbac9f19bab1a2d7366833b753

### DIFF
--- a/neutron/scheduler/dhcp_agent_scheduler.py
+++ b/neutron/scheduler/dhcp_agent_scheduler.py
@@ -22,6 +22,7 @@ from oslo.config import cfg
 from neutron.common import constants
 from neutron.db import agents_db
 from neutron.db import agentschedulers_db
+from neutron.openstack.common.db import exception as db_exc
 from neutron.openstack.common import log as logging
 
 
@@ -34,15 +35,25 @@ class ChanceScheduler(object):
     can be introduced later.
     """
 
-    def _schedule_bind_network(self, context, agent, network_id):
-        binding = agentschedulers_db.NetworkDhcpAgentBinding()
-        binding.dhcp_agent = agent
-        binding.network_id = network_id
-        context.session.add(binding)
-        LOG.debug(_('Network %(network_id)s is scheduled to be hosted by '
-                    'DHCP agent %(agent_id)s'),
-                  {'network_id': network_id,
-                   'agent_id': agent})
+    def _schedule_bind_network(self, context, agents, network_id):
+        for agent in agents:
+            context.session.begin(subtransactions=True)
+            try:
+                binding = agentschedulers_db.NetworkDhcpAgentBinding()
+                binding.dhcp_agent = agent
+                binding.network_id = network_id
+                context.session.add(binding)
+                # try to actually write the changes and catch integrity
+                # DBDuplicateEntry
+                context.session.commit()
+            except db_exc.DBDuplicateEntry:
+                # it's totally ok, someone just did our job!
+                context.session.rollback()
+                LOG.info(_('Agent %s already present'), agent)
+            LOG.debug(_('Network %(network_id)s is scheduled to be hosted by '
+                        'DHCP agent %(agent_id)s'),
+                    {'network_id': network_id,
+                    'agent_id': agent})
 
     def schedule(self, plugin, context, network):
         """Schedule the network to active DHCP agent(s).
@@ -79,8 +90,7 @@ class ChanceScheduler(object):
                 return
             n_agents = min(len(active_dhcp_agents), n_agents)
             chosen_agents = random.sample(active_dhcp_agents, n_agents)
-            for agent in chosen_agents:
-                self._schedule_bind_network(context, agent, network['id'])
+        self._schedule_bind_network(context, chosen_agents, network['id'])
         return chosen_agents
 
     def auto_schedule_networks(self, plugin, context, host):

--- a/neutron/tests/etc/neutron.conf.test
+++ b/neutron/tests/etc/neutron.conf.test
@@ -12,7 +12,7 @@ bind_host = 0.0.0.0
 bind_port = 9696
 
 # Path to the extensions
-api_extensions_path = unit/extensions
+api_extensions_path = neutron/tests/unit/extensions
 
 # Paste configuration file
 api_paste_config = api-paste.ini.test


### PR DESCRIPTION
Rarely dhcp agent rpc call get_active_networks_info() can interleave
with network scheduling initiated by create.port.end notification.
In this case scheduling raises and port creation returns 500.
Need to synchronize on DhcpNetworkBindings table.
Also made  minor modification to test config to fix extension path.

Closes-rally-bug: DE897
Closes-Bug: 1276552
Change-Id: I52d94a40772a99c7032dba15b200bf0f21362f93
Upstream-Review: https://review.openstack.org/#/c/71393/4
